### PR TITLE
【Fixed】Step#11 タスク一覧を作成日時の順番で並び替えました。

### DIFF
--- a/app/assets/stylesheets/tasks_index.scss
+++ b/app/assets/stylesheets/tasks_index.scss
@@ -7,5 +7,5 @@
   background-color: #dcdcdc;
   width: 300px;
   height: 300px;
-  margin-left: 10px;
+  margin: 0 0 10px 10px;
 }

--- a/app/assets/stylesheets/tasks_show.scss
+++ b/app/assets/stylesheets/tasks_show.scss
@@ -2,4 +2,5 @@
   background-color: #dcdcdc;
   width: 300px;
   height: 300px;
+  margin: 0 0 10px 10px;
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_params, only: [:show,:edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order("created_at DESC")
   end
 
   def new

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,17 @@
+# 「FactoryBotを使用します」という記述
+FactoryBot.define do
+
+  # 作成するテストデータの名前を「task」とします
+  # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
+  factory :task do
+    title { 'test_task_01' }
+    content { 'testtesttest' }
+  end
+
+  # 作成するテストデータの名前を「second_task」とします
+  # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
+  factory :second_task, class: Task do
+    title { 'test_task_02' }
+    content { 'samplesample' }
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -2,12 +2,18 @@
 require 'rails_helper'
 
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
-RSpec.feature "タスク管理機能", type: :feature do
+RSpec.feature "タスク機能（一覧と作成日時の降順）", type: :feature do
+  # background（before）を使って、「タスク管理機能」というカテゴリの中で使われるデータを共通化
+  background do
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
+  end
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   scenario "タスク一覧のテスト" do
     # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
-    Task.create!(title: 'test_task_01', content: 'testtesttest')
-    Task.create!(title: 'test_task_02', content: 'samplesample')
+    # 共通化したため、コメントアウト
+    # Task.create!(title: 'test_task_01', content: 'testtesttest')
+    # Task.create!(title: 'test_task_02', content: 'samplesample')
 
     # tasks_pathにvisitする（タスク一覧ページに遷移する）
     visit tasks_path
@@ -18,6 +24,14 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).to have_content 'samplesample'
   end
 
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    visit tasks_path
+    expect(Task.all.order(created_at: :desc)).to eq(Task.all.order(created_at: :desc))
+  end
+end
+
+RSpec.feature "タスク機能（作成と詳細）", type: :feature do
+
   scenario "タスク作成のテスト" do
     # new_task_pathにvisitする（タスク登録ページに遷移する）
     # 1.ここにnew_task_pathにvisitする処理を書く
@@ -26,13 +40,13 @@ RSpec.feature "タスク管理機能", type: :feature do
     # 「タスク名」というラベル名の入力欄と、「タスク詳細」というラベル名の入力欄に
     # タスクのタイトルと内容をそれぞれfill_in（入力）する
     # 2.ここに「タスク名」というラベル名の入力欄に内容をfill_in（入力）する処理を書く
-    fill_in 'Title', with: 'タスク名test'
+    fill_in 'タスク名', with: 'タスク名test'
     # 3.ここに「タスク詳細」というラベル名の入力欄に内容をfill_in（入力）する処理を書く
-    fill_in 'Content', with: 'タスク詳細test'
+    fill_in 'タスク詳細', with: 'タスク詳細test'
 
     # 「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）
     # 4.「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）する処理を書く
-    click_on '登録'
+    click_on '登録する'
 
     # 実際の状況を確認したい箇所にsave_and_open_pageメソッドをさし挟む。
     # このテストの場合「タスクが保存された後、タスク詳細ページに行くとどうなるのか」を確認するため
@@ -48,9 +62,7 @@ RSpec.feature "タスク管理機能", type: :feature do
 
   scenario "タスク詳細のテスト" do
     @task = Task.create!(title: 'タスク名test', content: 'タスク詳細test')
-
     visit task_path(@task.id)
-
     expect(page).to have_content 'タスク名test', 'タスク詳細test'
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,52 +1,60 @@
-# このrequireで、Capybaraなどの、Feature Specに必要な機能を使用可能な状態にしています
-require 'rails_helper'
+# requireで、Capybaraなどの、Feature Specに必要な機能を使用可能な状態にしている。
+require "rails_helper"
 
-# このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
-RSpec.feature "タスク機能（一覧と作成日時の降順）", type: :feature do
-  # background（before）を使って、「タスク管理機能」というカテゴリの中で使われるデータを共通化
+# RSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
+RSpec.feature "タスク管理機能（一覧・作成日時の降順・詳細）", type: :feature do
+  # background（Rspec -> before）を使って、「タスク管理機能（一覧と作成日時の降順）」というカテゴリの中で使われるデータを共通化
   background do
-    FactoryBot.create(:task)
-    FactoryBot.create(:second_task)
+    @task1 = FactoryBot.create(:task)
+    @task2 = FactoryBot.create(:second_task)
   end
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   scenario "タスク一覧のテスト" do
     # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
-    # 共通化したため、コメントアウト
     # Task.create!(title: 'test_task_01', content: 'testtesttest')
     # Task.create!(title: 'test_task_02', content: 'samplesample')
+    # 上記２行はbackground do ~ end内で共通化したため、コメントアウト
 
     # tasks_pathにvisitする（タスク一覧ページに遷移する）
     visit tasks_path
 
     # visitした（到着した）expect(page)に（タスク一覧ページに）「testtesttest」「samplesample」という文字列が
     # have_contentされているか？（含まれているか？）ということをexpectする（確認・期待する）テストを書いている
-    expect(page).to have_content 'testtesttest'
-    expect(page).to have_content 'samplesample'
+    expect(page).to have_content "testtesttest"
+    expect(page).to have_content "samplesample"
   end
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
     visit tasks_path
-    expect(Task.all.order(created_at: :desc)).to eq(Task.all.order(created_at: :desc))
+    # all メソッドでは条件に合致した要素の配列が返ってくる
+    all("div div")[0].click_link "詳細"
+    expect(page).to have_content "test_task_02"
+
+    visit tasks_path
+
+    all("div div")[1].click_link "詳細"
+    expect(page).to have_content "test_task_01"
+  end
+
+  scenario "タスク詳細のテスト" do
+    visit task_path(@task1.id)
+    expect(page).to have_content "test_task_01", "testtesttest"
   end
 end
 
-RSpec.feature "タスク機能（作成と詳細）", type: :feature do
+RSpec.feature "タスク管理機能（作成）", type: :feature do
 
   scenario "タスク作成のテスト" do
     # new_task_pathにvisitする（タスク登録ページに遷移する）
-    # 1.ここにnew_task_pathにvisitする処理を書く
     visit new_task_path
 
-    # 「タスク名」というラベル名の入力欄と、「タスク詳細」というラベル名の入力欄に
-    # タスクのタイトルと内容をそれぞれfill_in（入力）する
-    # 2.ここに「タスク名」というラベル名の入力欄に内容をfill_in（入力）する処理を書く
-    fill_in 'タスク名', with: 'タスク名test'
-    # 3.ここに「タスク詳細」というラベル名の入力欄に内容をfill_in（入力）する処理を書く
-    fill_in 'タスク詳細', with: 'タスク詳細test'
+    #「タスク名」というラベル名の入力欄に内容をfill_in（入力）する処理
+    fill_in "タスク名", with: "タスク名test"
+    #「タスク詳細」というラベル名の入力欄に内容をfill_in（入力）する処理
+    fill_in "タスク詳細", with: "タスク詳細test"
 
-    # 「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）
-    # 4.「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）する処理を書く
-    click_on '登録する'
+    #「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）する処理
+    click_on "登録する"
 
     # 実際の状況を確認したい箇所にsave_and_open_pageメソッドをさし挟む。
     # このテストの場合「タスクが保存された後、タスク詳細ページに行くとどうなるのか」を確認するため
@@ -55,14 +63,8 @@ RSpec.feature "タスク機能（作成と詳細）", type: :feature do
 
     # clickで登録されたはずの情報が、タスク詳細ページに表示されているかを確認する
     # （タスクが登録されたらタスク詳細画面に遷移されるという前提）
-    # 5.タスク詳細ページに、テストコードで作成したはずのデータ（記述）がhave_contentされているか（含まれているか）を確認（期待）するコードを書く
-    expect(page).to have_content 'タスク名test'
-    expect(page).to have_content 'タスク詳細test'
-  end
-
-  scenario "タスク詳細のテスト" do
-    @task = Task.create!(title: 'タスク名test', content: 'タスク詳細test')
-    visit task_path(@task.id)
-    expect(page).to have_content 'タスク名test', 'タスク詳細test'
+    # タスク詳細ページに、テストコードで作成したはずのデータ（記述）がhave_contentされているか（含まれているか）を確認（期待）するコード
+    expect(page).to have_content "タスク名test"
+    expect(page).to have_content "タスク詳細test"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,7 +64,7 @@ RSpec.configure do |config|
   # テスト用のデータを作成できないというエラーに直面することがある。
   # 'database_cleaner'というgemとセットで必要。
   config.before(:suite) do
-  DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :truncation
   end
 
   config.before(:all) do


### PR DESCRIPTION
## IDの順を作成日時の降順で並び替えるため、tasks_controller.rbのindexアクションを以下のように修正
class TasksController < ApplicationController
  def index
    @tasks = Task.all.order("created_at DESC")
  end
(中略)
end
## RSpec.feature "タスク管理機能", type: :feature do ~ end内の共通化できる部分を修正
- factory_bot_railsを利用したFactoryという機能を使用するためspec/factories/task.rbを作成し以下を記述しました。

FactoryBot.define do
  factory :task do
    title { 'test_task_01' }
    content { 'testtesttest' }
  end

  factory :second_task, class: Task do
    title { 'test_task_02' }
    content { 'samplesample' }
  end
end

- task.spec.rbに以下を追記

RSpec.feature "タスク管理機能", type: :feature do
  background do
    @task1 = FactoryBot.create(:task)
    @task2 = FactoryBot.create(:second_task)
  end
(中略)
end

## タスク一覧が作成日時の降順に並んでいるかテストするコードを追記
RSpec.feature "タスク管理機能", type: :feature do
(中略)
scenario "タスクが作成日時の降順に並んでいるかのテスト" do
visit tasks_path

all("div div")[0].click_link "詳細"
expect(page).to have_content "test_task_02"

visit tasks_path

all("div div")[1].click_link "詳細"
expect(page).to have_content "test_task_01"
(中略)
end