### PR TITLE
【Fixed】Step#12 バリデーションを設定しました。

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_params, only: [:show,:edit, :update, :destroy]
 
   def index
-    @tasks = Task.all.order("created_at DESC")
+    @tasks = Task.all.sorted
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 30 }
   validates :content, presence: true, length: { maximum: 255 }
+  scope :sorted, -> { order(created_at: :desc) }#created_atカラムを降順で取得する
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,4 @@
 class Task < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :content, presence: true, length: { maximum: 255 }
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,5 +1,15 @@
 <h3><%= t("views.edit.title") %></h3>
 <%= form_with(model: @task, local: true) do |f| %>
+  <% if @task.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= @task.errors.count %>件のエラーがあります。</h2>
+      <ul>
+        <% @task.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <p><%= f.label :title %></p>
   <p><%= f.text_field :title %></p>
   <p><%= f.label :content %></p>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -2,7 +2,7 @@
 <%= form_with(model: @task, local: true) do |f| %>
   <% if @task.errors.any? %>
     <div id="error_explanation">
-      <h2><%= @task.errors.count %>件のエラーがあります。</h2>
+      <h2><%= t("errors.template.header", model: @task.model_name.human, count: @task.errors.count) %></h2>
       <ul>
         <% @task.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,5 +1,15 @@
 <h3><%= t("views.new.title") %></h3>
 <%= form_with(model: @task, local: true) do |f| %>
+  <% if @task.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t("errors.template.header", model: @task.model_name.human, count: @task.errors.count) %></h2>
+      <ul>
+        <% @task.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <p><%= f.label :title %></p>
   <p><%= f.text_field :title %></p>
   <p><%= f.label :content %></p>

--- a/db/migrate/20181217014112_create_tasks.rb
+++ b/db/migrate/20181217014112_create_tasks.rb
@@ -1,8 +1,8 @@
 class CreateTasks < ActiveRecord::Migration[5.2]
   def change
     create_table :tasks do |t|
-      t.string :title
-      t.text :content
+      t.string :title, null: false, limit: 30
+      t.string :content, null: false, limit: 255
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(version: 2018_12_17_014112) do
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
+    t.string "title", limit: 30, null: false
+    t.string "content", limit: 255, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -4,14 +4,14 @@ FactoryBot.define do
   # 作成するテストデータの名前を「task」とします
   # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
   factory :task do
-    title { 'test_task_01' }
-    content { 'testtesttest' }
+    title { "test_task_01" }
+    content { "testtesttest" }
   end
 
   # 作成するテストデータの名前を「second_task」とします
   # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
   factory :second_task, class: Task do
-    title { 'test_task_02' }
-    content { 'samplesample' }
+    title { "test_task_02" }
+    content { "samplesample" }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+
+  it "titleが空ならバリデーションが通らない" do
+    task = Task.new(title: '', content: '失敗テスト')
+    expect(task).not_to be_valid
+  end
+
+  it "contentが空ならバリデーションが通らない" do
+    # ここに内容を記載する
+  end
+
+  it "titleとcontentに内容が記載されていればバリデーションが通る" do
+    # ここに内容を記載する
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,17 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Task, type: :model do
 
   it "titleが空ならバリデーションが通らない" do
-    task = Task.new(title: '', content: '失敗テスト')
-    expect(task).not_to be_valid
+    task = Task.new(title: "", content: "失敗テスト")
+    expect(task).not_to be_valid#be_validでvalid?メソッドを呼んで、それが返す値が（真 = true）ではない（not_to）ことを期待するテスト
   end
 
   it "contentが空ならバリデーションが通らない" do
-    # ここに内容を記載する
+    task = Task.new(title: "失敗テスト", content: "")
+    expect(task).not_to be_valid
   end
 
   it "titleとcontentに内容が記載されていればバリデーションが通る" do
-    # ここに内容を記載する
+    task = Task.new(title: "成功テスト", content: "成功テスト")
+    expect(task).to be_valid#be_validでvalid?メソッドを呼んで、それが返す値が（真 = true）である（to）ことを期待するテスト
   end
 end


### PR DESCRIPTION
## tasksテーブルのtitleカラムとcontentカラムにNOT NULL制約と文字数制限を追加しました。

  ```
create_table "tasks", force: :cascade do |t|

    t.string "title", limit: 30, null: false
    t.string "content", limit: 255, null: false
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false

end
```
## Taskモデルにtitleカラムとcontentカラムのバリデーションを設定しました。

```
class Task < ApplicationRecord

validates :title, presence: true, length: { maximum: 30 }
validates :content, presence: true, length: { maximum: 255 }

end
```

## バリデーションを通らなかったときにユーザーにエラーメッセージを表示させるコードを追記しました。

```
  <% if @task.errors.any? %>
    <div id="error_explanation">
      <h2><%= t("errors.template.header", model: @task.model_name.human, count:　@task.errors.count) %></h2>
      <ul>
        <% @task.errors.full_messages.each do |msg| %>
          <li><%= msg %></li>
        <% end %>
      </ul>
    </div>
  <% end %>
```
## モデルのテストを行いました。

- spec/models/task_spec.rbを作成し以下を記述。正しくバリデーションが効いていることを確認しました。

```
require "rails_helper"

RSpec.describe Task, type: :model do

  it "titleが空ならバリデーションが通らない" do
    task = Task.new(title: "", content: "失敗テスト")
    expect(task).not_to be_valid
  end

  it "contentが空ならバリデーションが通らない" do
    task = Task.new(title: "失敗テスト", content: "")
    expect(task).not_to be_valid
  end

  it "titleとcontentに内容が記載されていればバリデーションが通る" do
    task = Task.new(title: "成功テスト", content: "成功テスト")
    expect(task).to be_valid
  end

end
```
