### PR TITLE
【Fixed】Step#16 優先順位を設定しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
 - モデル名：Taskモデル
  - titleカラム => string型（１００文字以下）
  - contentカラム => string型（５００文字以下）
- - end_time_limitカラム => datetime型
- - priorityカラム => integer型
- - statusカラム => integer型
+ - end_time_limitカラム => datetime型、defalt: 現在時刻
+ - priorityカラム => integer型、defalt: 中
+ - statusカラム => integer型、defalt: 未着手
  - user_idカラム => references
  - index => titleカラム
  - index => statusカラム

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,10 +2,12 @@ class TasksController < ApplicationController
   before_action :set_params, only: [:show, :edit, :update, :destroy]
 
   def index
-    if params[:sort_expired]
-      @tasks = Task.all.end_time_limit_sorted.limit(30)
+    if params[:etl_sort]
+      @tasks = Task.end_time_limit_sorted.limit(30)#all省略
+    elsif params[:pri_sort]
+      @tasks = Task.priority_sorted.limit(30)#all省略
     else
-      @tasks = Task.all.created_at_sorted.limit(30)
+      @tasks = Task.created_at_sorted.limit(30)#all省略
     end
   end
 
@@ -64,6 +66,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :content, :status, "end_time_limit(1i)", "end_time_limit(2i)", "end_time_limit(3i)", "end_time_limit(4i)", "end_time_limit(5i)")
+    params.require(:task).permit(:title, :content, :status, :priority,
+                                 "end_time_limit(1i)", "end_time_limit(2i)", "end_time_limit(3i)", "end_time_limit(4i)", "end_time_limit(5i)")
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,6 +11,31 @@ class TasksController < ApplicationController
     end
   end
 
+  # # indexアクション内で検索するとき
+  # def index
+  #   # 「if文中のnilはfalseとして扱われる」if文中で、falseと同等の値として扱われるのはnilだけ。
+  #   # falseとnil以外の値、たとえば、0、[],””などはtrueとして扱われる。
+  #   if params[:etl_sort]#返り値がnil
+  #     @tasks = Task.end_time_limit_sorted.limit(30)#all省略
+  #   elsif params[:pri_sort]#返り値がnil
+  #     @tasks = Task.priority_sorted.limit(30)#all省略
+  #   # elsif params[:task][:search]#undefined method `[]' for nil:NilClassとなる([]を呼び出そうとしているが、その元のオブジェクトがnilであると言っている。)
+  #   elsif params[:task] && params[:task][:search]#params[:task]の返り値がnil
+  #     # present?を書かないとフィールドが空欄（""）でも検索しにいってしまいエラーが起こる？
+  #     if params[:task][:title].present? && params[:task][:status].present?
+  #       @tasks = Task.title_status_search(params[:task][:title], params[:task][:status])
+  #     elsif params[:task][:title].present?
+  #       @tasks = Task.title_search(params[:task][:title])
+  #     elsif params[:task][:status].present?
+  #       @tasks = Task.status_search(params[:task][:status])
+  #     elsif params[:task][:title].blank? && params[:task][:status].blank?
+  #       redirect_to tasks_path, notice: t("flash.blank")
+  #     end
+  #   else
+  #     @tasks = Task.created_at_sorted.limit(30)#all省略
+  #   end
+  # end
+
   def search
     # present?を書かないとフィールドが空欄（""）でも検索しにいってしまいエラーが起こる？
     if params[:task][:title].present? && params[:task][:status].present?

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,12 +3,16 @@ class Task < ApplicationRecord
   validates :content, presence: true, length: { maximum: 500 }
   validates :end_time_limit, presence: true
   validates :status, presence: true
+  validates :priority, presence: true
 
   scope :created_at_sorted, -> { order(created_at: :desc) }#created_atカラムを降順で取得する
   scope :end_time_limit_sorted, -> { order(end_time_limit: :desc) }#end_time_limitカラムを降順で取得する
+  scope :priority_sorted, -> { order(priority: :desc) }#priorityカラムを降順で取得する
   scope :title_search, -> (title) { where("title LIKE ?", "%#{ title }%") }#引数（title）で受け取った値と一致するレコードのみ検索
   scope :status_search, -> (status) { where(status: status) }#引数（status）で受け取った値と一致するレコードのみ検索
   scope :title_status_search, -> (title, status) { where("title LIKE ?", "%#{ title }%").where(status: status) }#引数（title, status）で受け取った値と両方成り立つレコードを検索
 
-  enum status: { waiting: 0, working: 1, completed: 2 }#enumを使えば、数字を意味のある文字として扱える。DBには割り当てられた整数が保存される。
+  # enumを使えば、数字を意味のある文字として扱える。DBには割り当てられた整数が保存される。
+  enum status: { waiting: 0, working: 1, completed: 2 }#ステータス
+  enum priority: { row: 0, medium: 1, high: 2 }#優先順位
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -18,6 +18,8 @@
   <p><%= f.datetime_select :end_time_limit %></p>
   <p><%= f.label :status %></p>
   <p><%= f.select :status, Task.statuses_i18n.invert %></p>
+  <p><%= f.label :priority %></p>
+  <p><%= f.select :priority, Task.priorities_i18n.invert %></p>
   <%= f.submit %>
   <p><%= link_to t("views.edit.back"), tasks_path %></p>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,6 +2,7 @@
 <!--ここでは、form_withの引数にある「model: Task.new」で空の引き出しを作り、その中に検索したいタイトル名や
 ステータス名を収納しコントローラに渡すことをしている。コントローラでは渡された情報を元にDBからwhere文などで
 一致したデータを引っ張り出してindex.html.erb内で表示する流れになっている。-->
+<!-- searchアクション内で検索するとき -->
 <%= form_with(model: Task.new, url: search_tasks_path, method: :get, local: true) do |f| %>
   <%= f.label :title_search, t("views.index.title_search") %>
   <%= f.text_field :title %>
@@ -9,12 +10,21 @@
   <%= f.select :status, Task.statuses_i18n.invert, include_blank: true, selected: "" %>
   <!-- f.select :status, Task.statuses.map{ |k, v|[t("enums.task.status.#{k}"), v] }だと「'0' is not valid status」のerrorが起こる。
   これは、taskインスタンスのstatusフィールドに整数の0ではなく、文字列の”0”を渡そうとしているからである。formはデフォルトで ""がついてしまっている。-->
-  <%#= f.hidden_field :search, value: "true" %>
-  <!-- controllerのindexアクション内で送られてきたparametersをif params[:task][:search]で拾おうとすると
-  「NoMethodError: undefined method `[]' for nil:NilClass」エラーが起こる。params[:search]とすると
-  エラーは起こらないが今度は検索ができなくなる。-->
   <%= f.submit t("views.index.search") %>
 <% end %>
+
+<% if false %>
+  <!-- indexアクション内で検索するとき -->
+  <%= form_with(model: Task.new, url: tasks_path, method: :get, local: true) do |f| %>
+    <%= f.label :title_search, t("views.index.title_search") %>
+    <%= f.text_field :title %>
+    <%= f.label :status_search, t("views.index.status_search") %>
+    <%= f.select :status, Task.statuses_i18n.invert, include_blank: true, selected: "" %>
+    <%= f.hidden_field :search, value: "true" %>
+    <%= f.submit t("views.index.search") %>
+  <% end %>
+<% end %>
+
 <%= link_to t("views.index.end_time_limit_sort"), tasks_path(etl_sort: "true") %> |
 <%= link_to t("views.index.priority_sort"), tasks_path(pri_sort: "true") %>
 <div class="index-box">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -15,8 +15,8 @@
   エラーは起こらないが今度は検索ができなくなる。-->
   <%= f.submit t("views.index.search") %>
 <% end %>
-
-<p><%= link_to t("views.index.end_time_limit_sort"), tasks_path(sort_expired: "true") %></p>
+<%= link_to t("views.index.end_time_limit_sort"), tasks_path(etl_sort: "true") %> |
+<%= link_to t("views.index.priority_sort"), tasks_path(pri_sort: "true") %>
 <div class="index-box">
   <% @tasks.each do |task| %>
     <div class="task_box">
@@ -24,6 +24,7 @@
       <p><%= Task.human_attribute_name :title %> : <%= task.title %></p>
       <p><%= Task.human_attribute_name :content %> : <%= task.content %></p>
       <p><%= Task.human_attribute_name :end_time_limit %> : <%= l(task.end_time_limit, format: :long) %></p>
+      <p><%= Task.human_attribute_name :priority %> : <%= task.priority_i18n %></p>
       <%= link_to t("views.index.show"), task_path(task.id) %> |
       <%= link_to t("views.index.edit"), edit_task_path(task.id) %> |
       <%= link_to t("views.index.destroy"), task_path(task.id), method: :delete %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -18,6 +18,8 @@
   <p><%= f.datetime_select :end_time_limit %></p>
   <p><%= f.label :status %></p>
   <p><%= f.select :status, Task.statuses_i18n.invert %></p>
+  <p><%= f.label :priority %></p>
+  <p><%= f.select :priority, Task.priorities_i18n.invert %></p>
   <%= f.submit %>
   <p><%= link_to t("views.new.back"), tasks_path %></p>
 <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,6 +4,7 @@
   <p><%= Task.human_attribute_name :title %> : <%= @task.title %></p>
   <p><%= Task.human_attribute_name :content %> : <%= @task.content %></p>
   <p><%= Task.human_attribute_name :end_time_limit %> : <%= l(@task.end_time_limit, format: :long) %></p>
+  <p><%= Task.human_attribute_name :priority %> : <%= @task.priority_i18n %></p>
   <%= link_to t("views.show.edit"), edit_task_path(@task.id) %> |
   <%= link_to t("views.show.destroy"), task_path(@task.id), method: :delete %>
   <p><%= link_to t("views.show.back"), tasks_path %></p>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -8,3 +8,4 @@ ja:
         content: "タスク詳細"
         end_time_limit: "終了期限"
         status: "状態"
+        priority: "優先順位"

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -6,6 +6,10 @@ ja:
     blank: "検索欄が空白です。何か入力してください。"
   enums:
     task:
+      priority:
+        row: "低"
+        medium: "中"
+        high: "高"
       status:
         waiting: "未着手"
         working: "着手中"
@@ -17,6 +21,7 @@ ja:
       edit: "編集"
       destroy: "削除"
       end_time_limit_sort: "終了期限でソートする"
+      priority_sort: "優先順位でソートする"
       search: "検索"
       title_search: "タスク名で絞り込む"
       status_search: "ステータスで絞り込む"

--- a/db/migrate/20190107150203_add_priority_to_tasks.rb
+++ b/db/migrate/20190107150203_add_priority_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddPriorityToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :priority, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_31_152419) do
+ActiveRecord::Schema.define(version: 2019_01_07_150203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2018_12_31_152419) do
     t.datetime "updated_at", null: false
     t.datetime "end_time_limit", default: -> { "now()" }, null: false
     t.integer "status", default: 0, null: false
+    t.integer "priority", default: 1, null: false
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     title { "test_task_01" }
     content { "testtesttest" }
     end_time_limit { DateTime.now }
+    status { 0 }
+    priority { 0 }
   end
 
   # 作成するテストデータの名前を「second_task」とします
@@ -15,5 +17,15 @@ FactoryBot.define do
     title { "test_task_02" }
     content { "samplesample" }
     end_time_limit { DateTime.tomorrow }
+    status { 0 }
+    priority { 1 }
+  end
+
+  factory :third_task, class: Task do
+    title { "test_task_03" }
+    content { "japan" }
+    end_time_limit { DateTime.now.since(3.days) }#3日後
+    status { 0 }
+    priority { 2 }
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -2,11 +2,12 @@
 require "rails_helper"
 
 # RSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
-RSpec.feature "タスク管理機能（一覧・作成日時の降順・詳細・終了期限のソート）", type: :feature do
+RSpec.feature "タスク管理機能（一覧・作成日時の降順・詳細・終了期限のソート・優先順位でソート）", type: :feature do
   # background（Rspec -> before）を使って、「タスク管理機能（一覧と作成日時の降順）」というカテゴリの中で使われるデータを共通化
   background do
     @task1 = FactoryBot.create(:task)
     @task2 = FactoryBot.create(:second_task)
+    @task3 = FactoryBot.create(:third_task)
   end
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   scenario "タスク一覧のテスト" do
@@ -28,12 +29,12 @@ RSpec.feature "タスク管理機能（一覧・作成日時の降順・詳細�
     visit tasks_path
     # all メソッドでは条件に合致した要素の配列が返ってくる
     all("div div")[0].click_link "詳細"
-    expect(page).to have_content "test_task_02"
+    expect(page).to have_content "test_task_03"
 
     visit tasks_path
 
     all("div div")[1].click_link "詳細"
-    expect(page).to have_content "test_task_01"
+    expect(page).to have_content "test_task_02"
   end
 
   scenario "タスク詳細のテスト" do
@@ -47,7 +48,27 @@ RSpec.feature "タスク管理機能（一覧・作成日時の降順・詳細�
     click_on "終了期限でソートする"
 
     all("div div")[0].click_link "詳細"
-    expect(page).to have_content "test_task_02"
+    expect(page).to have_content "test_task_03"
+  end
+
+  scenario "タスクが優先順位で降順に並んでいるかのテスト" do
+    visit tasks_path
+    click_on "優先順位でソートする"
+
+    all("div div")[0].click_link "詳細"
+    expect(page).to have_content "高"
+
+    visit tasks_path
+    click_on "優先順位でソートする"
+
+    all("div div")[1].click_link "詳細"
+    expect(page).to have_content "中"
+
+    visit tasks_path
+    click_on "優先順位でソートする"
+
+    all("div div")[2].click_link "詳細"
+    expect(page).to have_content "低"
   end
 
 end


### PR DESCRIPTION
1. tasksテーブルにpriorityカラムを追加
```
  create_table "tasks", force: :cascade do |t|
  (中略)
    t.integer "priority", default: 1, null: false
  end
```
2. task.rbに以下を追記
```
scope :priority_sorted, -> { order(priority: :desc) }
enum priority: { row: 0, medium: 1, high: 2 }
```
3. 一覧画面(index.html.erb)に優先順位でソートするリンクを作成
```
<%= link_to t("views.index.priority_sort"), tasks_path(pri_sort: "true") %>
```
4. tasks_controller.rbのindexアクション内を以下のように変更
```
  def index
    if params[:etl_sort]
      @tasks = Task.end_time_limit_sorted.limit(30)
    elsif params[:pri_sort]
      @tasks = Task.priority_sorted.limit(30)
    else
      @tasks = Task.created_at_sorted.limit(30)
    end
  end
```
5. タスクの入力(new.html.erb)・編集画面(edit.html.erb)に優先順位を入力するフィールドを追記
```
  <p><%= f.label :priority %></p>
  <p><%= f.select :priority, Task.priorities_i18n.invert %></p>
```
6. 優先順位を降順でソートできるかテスト
- spec/features/task.spec.rbに以下を追記
```
  scenario "タスクが優先順位で降順に並んでいるかのテスト" do
    visit tasks_path
    click_on "優先順位でソートする"

    all("div div")[0].click_link "詳細"
    expect(page).to have_content "高"

    visit tasks_path
    click_on "優先順位でソートする"

    all("div div")[1].click_link "詳細"
    expect(page).to have_content "中"

    visit tasks_path
    click_on "優先順位でソートする"

    all("div div")[2].click_link "詳細"
    expect(page).to have_content "低"
  end
```

